### PR TITLE
Replaces `double` with `float`

### DIFF
--- a/lepton/examples/sim_bell.c
+++ b/lepton/examples/sim_bell.c
@@ -19,7 +19,7 @@ void print_state_vector(complex *state_vector, int num_qubits)
     }
 }
 
-void print_probabilities_vector(double *probs_vector, int num_qubits)
+void print_probabilities_vector(float *probs_vector, int num_qubits)
 {
     unsigned int length = 1 << num_qubits;
     for (unsigned int i = 0; i < length; i++) {
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
     qubits_to_measure[0] = 0;
     qubits_to_measure[1] = 1;
 
-    double* probs = measurement_probabilities(current_state, 2, qubits_to_measure, 2);
+    float* probs = measurement_probabilities(current_state, 2, qubits_to_measure, 2);
 
     /* Print ideal measurement probabilities. */
     printf("Measurement ideal probabilities:\n");

--- a/lepton/lib/complex.c
+++ b/lepton/lib/complex.c
@@ -12,14 +12,14 @@ void print_complex(complex a)
 // Print a complex number in the polar format: (abs)exp((arg)i)
 void print_complex_polar(complex a)
 {
-    double magnitude = complex_abs(a);
-    double angle = complex_arg(a);
+    float magnitude = complex_abs(a);
+    float angle = complex_arg(a);
 
     printf("%f*exp(%fi)", magnitude, angle);
 }
 
 // Convert polar information into a standard complex number
-complex *polar_to_standard(double mag, double arg) {
+complex *polar_to_standard(float mag, float arg) {
     complex *a = (complex*)malloc(sizeof(complex));
     a->real = mag * cos(arg);
     a->imag = mag * sin(arg);
@@ -59,7 +59,7 @@ complex *multiply_complex(complex a, complex b)
 complex *divide_complex(complex a, complex b)
 {
     complex *c = (complex*)malloc(sizeof(complex));
-    double d = b.real * b.real + b.imag * b.imag;
+    float d = b.real * b.real + b.imag * b.imag;
     c->real = (a.real * b.real + a.imag * b.imag) / d;
     c->imag = (a.imag * b.real - a.real * b.imag) / d;
     return c;
@@ -68,13 +68,13 @@ complex *divide_complex(complex a, complex b)
 /* Basic operations*/
 
 // Absolute value (or modulus or magnitude) of a complex number
-double complex_abs(complex a)
+float complex_abs(complex a)
 {
     return sqrt(a.real * a.real + a.imag * a.imag);
 }
 
 // Argument (or phase) of a complex number
-double complex_arg(complex a)
+float complex_arg(complex a)
 {
     return atan2(a.imag, a.real);
 }

--- a/lepton/lib/complex.h
+++ b/lepton/lib/complex.h
@@ -7,13 +7,13 @@
 
 // Struct for a complex number
 typedef struct {
-    double real;
-    double imag;
+    float real;
+    float imag;
 } complex;
 
 extern void print_complex(complex a);
 extern void print_complex_polar(complex a);
-extern complex *polar_to_standard(double mag, double arg);
+extern complex *polar_to_standard(float mag, float arg);
 
 /* Arithmetic operations */
 extern complex *add_complex(complex a, complex b);
@@ -22,8 +22,8 @@ extern complex *multiply_complex(complex a, complex b);
 extern complex *divide_complex(complex a, complex b);
 
 /* Basic operations*/
-extern double complex_abs(complex a);
-extern double complex_arg(complex a);
+extern float complex_abs(complex a);
+extern float complex_arg(complex a);
 extern complex *complex_conjugate(complex a);
 
 #endif /* COMPLEX_H */

--- a/lepton/lib/gate.c
+++ b/lepton/lib/gate.c
@@ -103,7 +103,7 @@ sparse_element *h(
     debug("h: start")
     sparse_element gate[4];
 
-    double z = 1/sqrt(2);
+    float z = 1/sqrt(2);
 
     gate[0].row = 0;
     gate[0].col = 0;
@@ -132,7 +132,7 @@ sparse_element *h(
 
 
 sparse_element *rx(
-    double theta,
+    float theta,
     unsigned int num_qubits,
     unsigned int target,
     unsigned int *nnz
@@ -142,7 +142,7 @@ sparse_element *rx(
 }
 
 sparse_element *ry(
-    double theta,
+    float theta,
     unsigned int num_qubits,
     unsigned int target,
     unsigned int *nnz
@@ -152,7 +152,7 @@ sparse_element *ry(
 }
 
 sparse_element *rz(
-    double phi,
+    float phi,
     unsigned int num_qubits,
     unsigned int target,
     unsigned int *nnz
@@ -179,7 +179,7 @@ sparse_element *rz(
 
 
 sparse_element *p(
-    double lambda,
+    float lambda,
     unsigned int num_qubits,
     unsigned int target,
     unsigned int *nnz
@@ -190,9 +190,9 @@ sparse_element *p(
 
 
 sparse_element *u(
-    double theta,
-    double phi,
-    double lambda,
+    float theta,
+    float phi,
+    float lambda,
     unsigned int num_qubits,
     unsigned int target,
     unsigned int *nnz

--- a/lepton/lib/gate.h
+++ b/lepton/lib/gate.h
@@ -26,12 +26,12 @@ sparse_element *y(unsigned int num_qubits, unsigned int target, unsigned int *nn
 sparse_element *z(unsigned int num_qubits, unsigned int target, unsigned int *nnz);
 sparse_element *h(unsigned int num_qubits, unsigned int target, unsigned int *nnz);
 
-sparse_element *rx(double theta, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
-sparse_element *ry(double theta, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
-sparse_element *rz(double phi, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
-sparse_element *p(double lambda, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
+sparse_element *rx(float theta, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
+sparse_element *ry(float theta, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
+sparse_element *rz(float phi, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
+sparse_element *p(float lambda, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
 
-sparse_element *u(double theta, double phi, double lambda, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
+sparse_element *u(float theta, float phi, float lambda, unsigned int num_qubits, unsigned int target, unsigned int *nnz);
 
 sparse_element *cx(unsigned int num_qubits, unsigned int target, unsigned int control, unsigned int *nnz);
 sparse_element *cy(unsigned int num_qubits, unsigned int target, unsigned int control, unsigned int *nnz);

--- a/lepton/lib/measurement.c
+++ b/lepton/lib/measurement.c
@@ -3,7 +3,7 @@
 #include <math.h>
 #include "measurement.h"
 
-double* measurement_probabilities(
+float* measurement_probabilities(
     complex *state_vector,
     unsigned int num_qubits,
     unsigned int *qubits_to_measure,
@@ -15,13 +15,13 @@ double* measurement_probabilities(
     unsigned int length_state = 1 << num_qubits;
 
     /* Calculate the probability of measuring each state: |amp|^2 . */
-    double* probs = (double*)malloc(sizeof(double) * length_measure);
+    float* probs = (float*)malloc(sizeof(float) * length_measure);
     for (i = 0; i < length_measure; i++) {
         probs[i] = 0.0;
     }
 
     complex amp;
-    double prob;
+    float prob;
     unsigned int idx;
     for (i = 0; i < length_state; i++) {
         idx = 0;
@@ -39,7 +39,7 @@ double* measurement_probabilities(
 }
 
 unsigned int* measurement_counts(
-    double* probabilities,
+    float* probabilities,
     unsigned int num_qubits_measured,
     unsigned int shots
 )
@@ -53,11 +53,11 @@ unsigned int* measurement_counts(
     }
 
     /* Randomly select a state based on the probabilities. */
-    double* probs_ptr;
-    double rand_val;
-    double cum_prob;
+    float* probs_ptr;
+    float rand_val;
+    float cum_prob;
     for (j = 0; j < shots; j++) {
-        rand_val = ((double)rand() / RAND_MAX);
+        rand_val = ((float)rand() / RAND_MAX);
         cum_prob = 0.0;
         probs_ptr = probabilities;
         for (i = 0; i < length_measure; i++) {

--- a/lepton/lib/measurement.h
+++ b/lepton/lib/measurement.h
@@ -3,7 +3,7 @@
 
 #include "complex.h"
 
-extern double* measurement_probabilities(
+extern float* measurement_probabilities(
     complex *state_vector,
     unsigned int num_qubits,
     unsigned int *qubits_to_measure,
@@ -11,7 +11,7 @@ extern double* measurement_probabilities(
 );
 
 extern unsigned int* measurement_counts(
-    double* probabiblities,
+    float* probabiblities,
     unsigned int num_qubits_measured,
     unsigned int shots
 );

--- a/lepton/simulators/statevec.c
+++ b/lepton/simulators/statevec.c
@@ -81,7 +81,7 @@ void print_state_vector(complex *state_vector, unsigned int num_qubits)
     }
 }
 
-void print_probabilities_vector(double *probs_vector, unsigned int num_qubits)
+void print_probabilities_vector(float *probs_vector, unsigned int num_qubits)
 {
     unsigned int length = 1 << num_qubits;
     for (unsigned int i = 0; i < length; i++) {
@@ -235,8 +235,8 @@ complex *parse_qasm(
                 debug2("parse_qasm: instruction2 = %s", instruction2)
                 debug2("parse_qasm: qubit_target = %u", qubit_target)
 
-                double parameter_value;
-                double parameter_value2;
+                float parameter_value;
+                float parameter_value2;
 
                 char *slash;
                 slash = strchr(instruction2, '/');
@@ -488,7 +488,7 @@ int main(int argc, char** argv)
     }
 
     /* Print ideal measurement probabilities. */
-    double* probs = measurement_probabilities(
+    float* probs = measurement_probabilities(
             state_vector,
             num_qubits,
             qubits_to_measure,

--- a/make/cpm/Makefile
+++ b/make/cpm/Makefile
@@ -18,9 +18,9 @@ build:
 	@$(CC) $(CCFLAGS) -c $(LIB)/sparse_matrix.c -o $(BIN)/sparse_matrix.o
 	@$(CC) $(CCFLAGS) -c $(LIB)/measurement.c -o $(BIN)/measurement.o
 	@$(CC) $(CCFLAGS) -c $(LIB)/gate.c -o $(BIN)/gate.o
-	@$(CC) $(CCFLAGS) $(EXAMPLES)/sim_bell.c $(BIN)/complex.o $(BIN)/sparse_matrix.o $(BIN)/measurement.o $(BIN)/gate.o -o $(BIN)/simbell.com -lmath48 -DAMALLOC -lndos
+	@$(CC) $(CCFLAGS) $(EXAMPLES)/sim_bell.c $(BIN)/complex.o $(BIN)/sparse_matrix.o $(BIN)/measurement.o $(BIN)/gate.o -o $(BIN)/simbell.com -lm -DAMALLOC -lndos
 	@$(CC) $(CCFLAGS) $(TOOLS)/drafter.c -o $(BIN)/drafter.com -DAMALLOC
-	@$(CC) $(CCFLAGS) $(SIMULATORS)/statevec.c $(BIN)/complex.o $(BIN)/sparse_matrix.o $(BIN)/measurement.o $(BIN)/gate.o -o $(BIN)/statevec.com -lmath48 -DAMALLOC
+	@$(CC) $(CCFLAGS) $(SIMULATORS)/statevec.c $(BIN)/complex.o $(BIN)/sparse_matrix.o $(BIN)/measurement.o $(BIN)/gate.o -o $(BIN)/statevec.com -lm -DAMALLOC
 
 clean:
 	@rm -f $(BIN)/*.c $(BIN)/*.h $(BIN)/*.o


### PR DESCRIPTION
It reduces the memory needed to store the state vector and has no noticeable impact on the results.